### PR TITLE
Suppress implicit type conversion

### DIFF
--- a/src/CommonProcessingUnit.cpp
+++ b/src/CommonProcessingUnit.cpp
@@ -78,7 +78,7 @@ namespace CommonProcessingUnit
         for (int y = 0; y < dispf.rows; ++y) {
             for (int x = 0; x < dispf.cols; ++x) {
                 cv::Vec3f &point = XYZ.at<cv::Vec3f>(y, x);
-                int dis = dispf.at<float_t>(y, x);
+                float dis = dispf.at<float_t>(y, x);
                 if (dis == 0) {
                     point[2] = NAN;
                     continue;


### PR DESCRIPTION
We found an implicit type conversion which may occur point clouds issue
reported in https://github.com/fixstars/libSGM/issues/46 .

|before|after|
|-|-|
|![snapshot01](https://user-images.githubusercontent.com/45864601/63334728-f6760e00-c376-11e9-9184-dfecab429ba6.png)|![snapshot00](https://user-images.githubusercontent.com/45864601/63334733-fbd35880-c376-11e9-8747-2a466931bdd9.png)|